### PR TITLE
Attempt to give err.stack to browsers outside of V8

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -88,6 +88,12 @@ assert.AssertionError = function AssertionError(options) {
 
   if (Error.captureStackTrace) {
     Error.captureStackTrace(this, stackStartFunction);
+  } else {
+    // try to throw an error now, and from the stack property
+    // work out the line that called in to assert.js.
+    try {
+      this.stack = (new Error).stack.toString();
+    } catch (e) {}
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Porting Node.js assert.js to browser",
   "contributors": [
     "Jxck <block.rxckin.beats@gmail.com>",
-    "Oscar Godson <oscargodson@gmail.com>"
+    "Oscar Godson <oscargodson@gmail.com>",
+    "Remy Sharp <remy@remysharp.com>"
   ],
   "repository": "git@github.com:Jxck/assert.git"
 }


### PR DESCRIPTION
Throwing an exception and in a dirty way, looking for a .stack property. If it's there, store _that_ line as the .stack property of our custom error object.

Really helps with visibility with tools like Karma and testem.

(added my name in the contrib package - looking back, feel free to pull it out, my change wasn't that much of a contrib :)
