### PR TITLE
Restore Error.captureStackTrace checking

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -142,7 +142,15 @@ assert.AssertionError = function AssertionError(options) {
     this.generatedMessage = true;
   }
   var stackStartFunction = options.stackStartFunction || fail;
-  Error.captureStackTrace(this, stackStartFunction);
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, stackStartFunction);
+  } else {
+    // try to throw an error now, and from the stack property
+    // work out the line that called in to assert.js.
+    try {
+      this.stack = (new Error).stack.toString();
+    } catch (e) {}
+  }
 };
 
 // assert.AssertionError instanceof Error


### PR DESCRIPTION
commit [35e4195cacf](https://github.com/Jxck/assert/commit/35e4195cacf520ed029ddc42b00a710e81a31be4) has lost Error.captureStackTrace check again. fixes #8 (again)
