### PR TITLE
General UMD support

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -24,11 +24,15 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(function(module) {
-
-if (typeof module.exports === 'undefined') {
-  module.exports = module; // this case must be browser
-}
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory); // AMD
+  } else if (typeof exports === 'object') {
+    module.exports = factory(); // CommonJS
+  } else {
+    root.assert = factory(); // Global
+  }
+})(this, function() {
 
 // UTILITY
 
@@ -122,7 +126,7 @@ var Object_keys = typeof Object.keys === 'function'
 // AssertionError's when particular conditions are not met. The
 // assert module must conform to the following interface.
 
-var assert = module.exports = ok;
+var assert = ok;
 
 // 2. The AssertionError is defined in assert.
 // new assert.AssertionError({ message: message,
@@ -426,5 +430,5 @@ assert.doesNotThrow = function(block, /*optional*/message) {
 
 assert.ifError = function(err) { if (err) {throw err;}};
 
-module.assert = module.exports;
-})(this);
+return assert;
+});

--- a/test/index-amd.html
+++ b/test/index-amd.html
@@ -2,15 +2,7 @@
 <html>
   <head>
     <title>Test Assert</title>
-    <script type="text/javascript" src="http://requirejs.org/docs/release/2.1.2/comments/require.js"></script>
-    <script type="text/javascript">
-    require(['../assert'], function () {
-      var tag = document.createElement('script');
-      tag.setAttribute('type', 'text/javascript');
-      tag.setAttribute('src', 'test-assert.js');
-      document.getElementsByTagName('head')[0].appendChild(tag);
-    });
-    </script>
+    <script data-main="./test-assert" src="http://requirejs.org/docs/release/2.1.15/comments/require.js"></script>
   </head>
   <body>
     <h1>Test Assert</h1>

--- a/test/test-assert.js
+++ b/test/test-assert.js
@@ -19,11 +19,17 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-(function(require) {
+(function(root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['../assert'], factory); // AMD
+    } else if (typeof exports === 'object') {
+        factory(require('../assert')); // CommonJS
+    } else {
+        factory(root.assert); // Global
+    }
+})(this, function(assert) {
 
-// var common = require('../common');
-var assert = require('assert');
-var a = require('assert');
+var a = assert;
 
 function makeBlock(f) {
   var args = Array.prototype.slice.call(arguments, 1);
@@ -31,9 +37,6 @@ function makeBlock(f) {
     return f.apply(this, args);
   };
 }
-
-// assert.ok(common.indirectInstanceOf(a.AssertionError.prototype, Error),
-//           'a.AssertionError instanceof Error');
 
 assert.throws(makeBlock(a, false), a.AssertionError, 'ok(false)');
 
@@ -256,7 +259,6 @@ var args = (function() { return arguments; })();
 a.throws(makeBlock(a.deepEqual, [], args));
 a.throws(makeBlock(a.deepEqual, args, []));
 
-console.log('All OK');
 assert.ok(gotError);
 
 
@@ -306,20 +308,17 @@ assert.ok(threw);
 try {
   assert.equal(1, 2);
 } catch (e) {
-  assert.equal(e.toString().split('\n')[0], 'AssertionError: 1 == 2')
+  assert.equal(e.toString().split('\n')[0], 'AssertionError: 1 == 2');
   assert.ok(e.generatedMessage, 'Message not marked as generated');
 }
 
 try {
   assert.equal(1, 2, 'oh no');
 } catch (e) {
-  assert.equal(e.toString().split('\n')[0], 'AssertionError: oh no')
+  assert.equal(e.toString().split('\n')[0], 'AssertionError: oh no');
   assert.equal(e.generatedMessage, false,
               'Message incorrectly marked as generated');
 }
 
-})(function require(name) {
-  if (this[name]) {
-    return this[name];
-  }
+console.log('All OK');
 });


### PR DESCRIPTION
135630e broke [UMD pattern](https://github.com/umdjs/umd), mentioned in https://github.com/Jxck/assert/issues/15#issuecomment-64975489 by @twada.
To resolve it, this pul-req introduces general UMD support to `assert.js` and `test-assert.js`.
